### PR TITLE
Fix incorrect `from` strings used with `nodemailer` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ describe("SmtpServer", () => {
 
 		// Send an e-mail with nodemailer.
 		const info = await transporter.sendMail({
-			from: "test@smtpsaurus.email",
+			from: `"smtpsaurus" <test@smtpsaurus.email>`,
 			to: "user@smtpsaurus.com",
 			subject: "Test Email",
 			text: "Hello, world!",

--- a/src/smtpsaurus.ts
+++ b/src/smtpsaurus.ts
@@ -63,7 +63,7 @@ export type ServerConfig = {
  *
  *     // Send an e-mail with nodemailer.
  *     const info = await transporter.sendMail({
- *       from: "test@smtpsaurus.email",
+ *       from:`"smtpsaurus" <test@smtpsaurus.email>`,
  *       to: "user@smtpsaurus.com",
  *       subject: "Test Email",
  *       text: "Hello, world!",


### PR DESCRIPTION
This PR fixes missing name and non-standard formatting in strings used for the `nodemailer` `from` field. Those strings can cause `smtpsaurus` to crash due `null` results from regex matching. We will provide more meaningful error messages when we implement better validation in the future.

## Checklist

- [x] All tests passed.
- [x] No linting errors.