### PR TITLE
Implement find port on conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.1.2
+
+- Implement the ability for `smtpsaurus` to optionally find an open port to
+  listen on when the one specified is already in use, which may be useful for
+  circumventing the address in use error (`Deno.errors.AddrInUse`) when running
+  tests in parallel. The new constructor option is `findPortOnConflict`, which
+  defaults to `false`.
+- Fix incorrect `from` strings given to `nodemailer` in code examples.
+
 ## v0.1.1
 
 - Fix linting issues.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ describe("SmtpServer", () => {
 	let server: SmtpServer;
 
 	beforeEach(() => {
-		server = new SmtpServer();
+		// Setting `findPortOnConflict` to `true` may be useful when running
+		// tests in parallel, as it allows `smtpsaurus` to find an open
+		// automatically if the one specified is in use.
+		server = new SmtpServer({ port: 42024, findPortOnConflict: true });
 	});
 
 	afterEach(async () => {

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"lock": true,
 	"name": "@smtpsaurus/smtpsaurus",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"license": "MIT",
 	"exports": "./src/mod.ts",
 	"publish": {

--- a/src/smtpsaurus.test.ts
+++ b/src/smtpsaurus.test.ts
@@ -259,6 +259,36 @@ describe("SmtpServer", () => {
 			await connection.close();
 		});
 	});
+
+	describe("attempting to start multiple instances with the same port number", () => {
+		it("throws an address in use error", async () => {
+			const server = new SmtpServer();
+
+			expect(() => new SmtpServer()).toThrow(Deno.errors.AddrInUse);
+
+			await server.stop();
+		});
+
+		it("starts a new service at the next available port when `findOpenPort` is set to true", () => {
+			const port = 42024;
+
+			const server1 = new SmtpServer({
+				port,
+				findPortOnConflict: true,
+			});
+
+			const server2 = new SmtpServer({
+				port,
+				findPortOnConflict: true,
+			});
+
+			expect(server1.port).toBe(port);
+			expect(server2.port).toBe(port + 1);
+
+			server1.stop();
+			server2.stop();
+		});
+	});
 });
 
 function createConnection(): Promise<Deno.TcpConn> {

--- a/src/smtpsaurus.ts
+++ b/src/smtpsaurus.ts
@@ -57,7 +57,10 @@ export type ServerConfig = {
  *   let server: SmtpServer;
  *
  *   beforeEach(() => {
- *     server = new SmtpServer();
+ *     // Setting `findPortOnConflict` to `true` may be useful when running
+ *     // tests in parallel, as it allows `smtpsaurus` to find an open
+ *     // automatically if the one specified is in use.
+ *     server = new SmtpServer({ port: 42024, findPortOnConflict: true });
  *	 });
  *
  *   afterEach(async () => {

--- a/src/smtpsaurus.ts
+++ b/src/smtpsaurus.ts
@@ -23,6 +23,16 @@ export type ServerConfig = {
 	domain?: string;
 
 	/**
+	 * A flag that indicates whether or not `smtpsaurus` should attempt to find
+	 * an open port to start `smtpsaurus` on in the event that a port is already
+	 * in use. Setting this to true may be necessary when running tests in
+	 * parallel. `smtpsaurus` simply increment the base port number by 1 until
+	 * an open one is found.
+	 * @default false
+	 */
+	findPortOnConflict?: boolean;
+
+	/**
 	 * Optional port number for the server.
 	 * @default DEFAULT_PORT
 	 */
@@ -149,10 +159,35 @@ export class SmtpServer {
 		this.port = config?.port ?? DEFAULT_PORT;
 		this.hostname = DEFAULT_HOSTNAME;
 
-		this.listener = Deno.listen({
-			hostname: this.hostname,
-			port: this.port,
-		});
+		if (!config?.findPortOnConflict) {
+			this.listener = Deno.listen({
+				hostname: this.hostname,
+				port: this.port,
+			});
+		} else {
+			while (!this.listener && this.port <= 65535) {
+				try {
+					this.listener = Deno.listen({
+						hostname: this.hostname,
+						port: this.port,
+					});
+				} catch (error) {
+					if (error instanceof Deno.errors.AddrInUse) {
+						this.port++;
+
+						continue;
+					}
+
+					throw error;
+				}
+			}
+		}
+
+		if (!this.listener) {
+			throw new Error(
+				"😰 smtpsaurus could not find an open port to listen on!",
+			);
+		}
 
 		console.log(
 			`🦕 smtpsaurus listening at ${this.listener.addr.hostname} on port ${this.port}.`,


### PR DESCRIPTION
This PR adds a `findPortOnConflict` option so that `smtpsaurus` will attempt to find an open port when the one specified (or the default port) is already in use.

Setting this to true may be necessary when running tests in parallel. `smtpsaurus` simply increment the base port number by 1 until an open one is found.


## Checklist

- [x] All tests passed.
- [x] No linting errors.