### PR TITLE
Add a quiet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.3
+
+- Add the ability to run `smtpsaurus` under quiet mode, which stops `smtpsaurus`
+  from logging to STDOUT.
+
 ## v0.1.2
 
 - Implement the ability for `smtpsaurus` to optionally find an open port to

--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ describe("SmtpServer", () => {
 		// Setting `findPortOnConflict` to `true` may be useful when running
 		// tests in parallel, as it allows `smtpsaurus` to find an open
 		// automatically if the one specified is in use.
-		server = new SmtpServer({ port: 42024, findPortOnConflict: true });
+		server = new SmtpServer({
+			port: 42024,
+			findPortOnConflict: true
+			quiet: true
+		});
 	});
 
 	afterEach(async () => {

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"lock": true,
 	"name": "@smtpsaurus/smtpsaurus",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"license": "MIT",
 	"exports": "./src/mod.ts",
 	"publish": {

--- a/src/smtpsaurus.ts
+++ b/src/smtpsaurus.ts
@@ -66,7 +66,11 @@ export type ServerConfig = {
  *     // Setting `findPortOnConflict` to `true` may be useful when running
  *     // tests in parallel, as it allows `smtpsaurus` to find an open
  *     // automatically if the one specified is in use.
- *     server = new SmtpServer({ port: 42024, findPortOnConflict: true });
+ *     server = new SmtpServer({
+ *       port: 42024,
+ *       findPortOnConflict: true,
+ *       quiet: true,
+ *     });
  * 	 });
  *
  *   afterEach(async () => {


### PR DESCRIPTION
This PR introduces a quiet mode that `smtpsaurus` can be instantiated with. To enable quiet mode, simply create and `smaptsaurus` instance with the `quiet` option set to `true`:

```ts
const smtpsaurus = new SmtpServer({ quiet: true });
```


## Checklist

- [x] All tests passed.
- [x] No linting errors.