### PR TITLE
Prevent smtpsaurus from listening upon instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
+## v0.2.0
+
+⚠️ This version contains a breaking change and the unofficial support for
+version 1.45.0 has now been dropped.
+
+- Instantiating a new instance with new SmtpServer() no longer starts the server
+  automatically. To start a server, call the start() method on the server
+  instance. This change was introduced so that the caller can have greater
+  control over the lifecycle of a smtpsaurus instance, especially in test
+  environments.
+- Add a `isListening` method for determining whether or not an `smtpsaurus`
+  instance has started.
+
 ## v0.1.3
 
-- Add the ability to run `smtpsaurus` under quiet mode, which stops `smtpsaurus`
+- Add the ability to run `smtpsaurus` in quiet mode, which stops `smtpsaurus`
   from logging to STDOUT.
 
 ## v0.1.2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-`smtpsaurus` is a local SMTP server built for Deno **test** environments. It
+`smtpsaurus` is a local SMTP server built for Deno 2 for testing purposes. It
 implements basic functionality for receiving and storing e-mails, and provides
 an API for fetching stored e-mails.
 
@@ -11,9 +11,6 @@ not be used in production systems. It currently lacks features such as TLS,
 authentication, and has minimal validation and error handling.
 
 ## Installation
-
-`smtpsaurus` is written with Deno 2 in mind. While version 1 is not officially
-supported, tests are passing in version 1.45.0.
 
 To add `smtpsaurus` to your Deno project:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ import { SmtpServer } from "jsr:@smtpsaurus/smtpsaurus";
 // Creating a new instance and starting the server.
 const server = new SmtpServer();
 
+// Start the server.
+server.start();
+
 // Retrieving e-mails.
 const messageId = "<b3e84b8d-0128-422e-ba89-af074e87d28e@smtpsaurus.email>";
 const senderEmail = "rawr@smtpsaurus.email";
@@ -56,6 +59,8 @@ const server = new SmtpServer({
 	domain: "happy-smtpsaurus.email",
 	port: 65535,
 });
+
+server.start();
 ```
 
 ## API documentation
@@ -86,6 +91,8 @@ describe("SmtpServer", () => {
 			findPortOnConflict: true
 			quiet: true
 		});
+
+		server.start();
 	});
 
 	afterEach(async () => {

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"lock": true,
 	"name": "@smtpsaurus/smtpsaurus",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"license": "MIT",
 	"exports": "./src/mod.ts",
 	"publish": {

--- a/deno.lock
+++ b/deno.lock
@@ -14,6 +14,7 @@
     "jsr:@std/path@^1.0.8": "1.0.9",
     "jsr:@std/path@^1.0.9": "1.0.9",
     "jsr:@std/testing@^1.0.11": "1.0.11",
+    "npm:@types/node@*": "22.12.0",
     "npm:@types/nodemailer@*": "6.4.17",
     "npm:nodemailer@^7.0.2": "7.0.2"
   },

--- a/src/smtpsaurus.test.ts
+++ b/src/smtpsaurus.test.ts
@@ -304,6 +304,30 @@ describe("SmtpServer", () => {
 			}
 		});
 	});
+
+	describe("`isListening()", () => {
+		let server: SmtpServer;
+
+		beforeEach(() => {
+			server = new SmtpServer();
+		});
+
+		afterEach(async () => {
+			await server.stop();
+		});
+
+		it("correctly describes the state of the server", async () => {
+			expect(server.isListening()).toBe(false);
+
+			server.start();
+
+			expect(server.isListening()).toBe(true);
+
+			await server.stop();
+
+			expect(server.isListening()).toBe(false);
+		});
+	});
 });
 
 function createConnection(): Promise<Deno.TcpConn> {

--- a/src/smtpsaurus.ts
+++ b/src/smtpsaurus.ts
@@ -355,7 +355,8 @@ export class SmtpServer {
 	/**
 	 * @private
 	 * Main loop for handling incoming connections.
-	 * This method runs continuously, accepting new connections and processing them.
+	 * This method runs continuously, accepting new connections and processing
+	 * them.
 	 *
 	 * @returns Promise that resolves when the server stops
 	 */
@@ -375,6 +376,16 @@ export class SmtpServer {
 				throw error;
 			}
 		}
+	}
+
+	/**
+	 * Check whether or not the server has started and is listening.
+	 *
+	 * @returns A boolean that indicates whether or not the server
+	 * is listening.
+	 */
+	isListening(): boolean {
+		return !!this.listener;
 	}
 
 	/**

--- a/src/smtpsaurus.ts
+++ b/src/smtpsaurus.ts
@@ -71,6 +71,8 @@ export type ServerConfig = {
  *       findPortOnConflict: true,
  *       quiet: true,
  *     });
+ *
+ *     server.start();
  * 	 });
  *
  *   afterEach(async () => {
@@ -150,6 +152,13 @@ export class SmtpServer {
 
 	/**
 	 * @private
+	 * A flag that indicates whether or not `smtpsaurus` should attempt to find
+	 * another open port to start `smtpsaurus` on in the event of a conflict.
+	 */
+	private findPortOnConflict: boolean = false;
+
+	/**
+	 * @private
 	 * TCP listener for incoming connections.
 	 */
 	private listener: Deno.TcpListener | undefined;
@@ -161,7 +170,7 @@ export class SmtpServer {
 	 * a connection closes or when we call `close()`, or when an unhandled
 	 * exception occurs.
 	 */
-	private mainLoopExitSignal: Promise<void>;
+	private mainLoopExitSignal: Promise<void> | undefined;
 
 	/**
 	 * @private
@@ -192,42 +201,7 @@ export class SmtpServer {
 		this.port = config?.port ?? DEFAULT_PORT;
 		this.hostname = DEFAULT_HOSTNAME;
 		this.quiet = !!config?.quiet;
-
-		if (!config?.findPortOnConflict) {
-			this.listener = Deno.listen({
-				hostname: this.hostname,
-				port: this.port,
-			});
-		} else {
-			while (!this.listener && this.port <= 65535) {
-				try {
-					this.listener = Deno.listen({
-						hostname: this.hostname,
-						port: this.port,
-					});
-				} catch (error) {
-					if (error instanceof Deno.errors.AddrInUse) {
-						this.port++;
-
-						continue;
-					}
-
-					throw error;
-				}
-			}
-		}
-
-		if (!this.listener) {
-			throw new Error(
-				"😰 smtpsaurus could not find an open port to listen on!",
-			);
-		}
-
-		this.log(
-			`🦕 smtpsaurus listening at ${this.listener.addr.hostname} on port ${this.port}.`,
-		);
-
-		this.mainLoopExitSignal = this.startMainLoop();
+		this.findPortOnConflict = !!config?.findPortOnConflict;
 	}
 
 	/**
@@ -404,6 +378,47 @@ export class SmtpServer {
 	}
 
 	/**
+	 * Start the server.
+	 */
+	start(): void {
+		if (this.findPortOnConflict) {
+			while (!this.listener && this.port <= 65535) {
+				try {
+					this.listener = Deno.listen({
+						hostname: this.hostname,
+						port: this.port,
+					});
+				} catch (error) {
+					if (error instanceof Deno.errors.AddrInUse) {
+						this.port++;
+
+						continue;
+					}
+
+					throw error;
+				}
+			}
+		} else {
+			this.listener = Deno.listen({
+				hostname: this.hostname,
+				port: this.port,
+			});
+		}
+
+		if (!this.listener) {
+			throw new Error(
+				"😰 smtpsaurus could not find an open port to listen on!",
+			);
+		}
+
+		this.log(
+			`🦕 smtpsaurus listening at ${this.listener.addr.hostname} on port ${this.port}.`,
+		);
+
+		this.mainLoopExitSignal = this.startMainLoop();
+	}
+
+	/**
 	 * Stop the server.
 	 *
 	 * @returns Promise that resolves when the listener has closed and the
@@ -412,6 +427,7 @@ export class SmtpServer {
 	async stop(): Promise<void> {
 		this.listener?.close();
 		this.listener = undefined;
+
 		await this.mainLoopExitSignal;
 	}
 }


### PR DESCRIPTION
# ⚠️ This PR contains a breaking change!

Creating a new`smtpsaurus` instance always automatically starts an SMTP server. While this behaviour works well for cases where we keep a single instance of `smtpsaurus` running in the background, the lack of control over when `smtpsaurus` starts and stop can lead to unexpected behaviours, and/or async leaks in tests that are difficult to work around.

This PR removes that behaviour and introduces a `start()` method for the caller to control when an `smtpsaurus` instance should begin listening. I have also introduced a `isListening()` method for determining whether or not an `smtpsaurus` instance is listening for runtime control.


## Migration instructions

To preserve the behaviour from the previous versions (0.1.x), call the `start()` method after where `smtpsaurus` is instantiated:

```ts
import { SmtpServer } from "@smtpsaurus/smtpsaurus";

// 0.1.x
const server = new SmtpServer();


// 0.2.0
const server = new SmtpServer();

server.start();
```


## Checklist

- [x] All tests passed.
- [x] No linting errors.